### PR TITLE
perf(indexer): 1500% speedup

### DIFF
--- a/back/src/main/java/com/fadgiras/searchengine/controller/MainController.java
+++ b/back/src/main/java/com/fadgiras/searchengine/controller/MainController.java
@@ -255,6 +255,7 @@ public class MainController {
                 e.printStackTrace();
             }
             logger.trace("processing words");
+
             for (String s : tokens) {
                 Index index = new Index(book, s, 1);
 
@@ -268,7 +269,7 @@ public class MainController {
             }
             logger.trace("processed words");
             logger.trace("saving indexes");
-            indexRepository.saveAll(allIndexes.stream().toList());
+            indexRepository.saveAll(allIndexes);
             logger.trace("saved indexes");
         }
 

--- a/back/src/main/java/com/fadgiras/searchengine/controller/MainController.java
+++ b/back/src/main/java/com/fadgiras/searchengine/controller/MainController.java
@@ -239,9 +239,9 @@ public class MainController {
 
     @RequestMapping(value = "/indexer", produces = "application/json")
     public String indexer() {
-        List<Index> allIndexes = bookRepository.findAll()
+        bookRepository.findAll()
                 .parallelStream()
-                .map(book -> {
+                .forEach(book -> {
                     logger.trace("processing book: {}", book.getTitle());
                     try {
                         logger.trace("stemming book: {}", book.getTitle());
@@ -257,20 +257,13 @@ public class MainController {
                         ).toList();
 
                         logger.trace("processed words");
-
-                        return bookIndexes;
+                        logger.trace("saving indexes");
+                        indexRepository.saveAll(bookIndexes);
+                        logger.trace("saved indexes");
                     } catch (Exception e) {
                         e.printStackTrace();
-                        return null;
                     }
-                }).filter(Objects::nonNull)
-                .flatMap(Collection::stream)
-                .toList();
-
-        logger.trace("saving indexes");
-        indexRepository.saveAll(allIndexes);
-        logger.trace("saved indexes");
-
+                });
         return "ok";
     }
 

--- a/back/src/main/java/com/fadgiras/searchengine/controller/MainController.java
+++ b/back/src/main/java/com/fadgiras/searchengine/controller/MainController.java
@@ -245,12 +245,6 @@ public class MainController {
         for (Book book : books) {
             //get index from database
             List<Index> allIndexes = indexRepository.getIndexByBook(book);
-//            List<RIndex> allRIndexes = RIndexRepository.findAll();
-
-
-            List<Index> currentIndexes = new ArrayList<>();
-            List<RIndex> currentRIndexes = new ArrayList<>();
-
 
             logger.info("processing book: " + book.getTitle());
             List<String> tokens = new ArrayList<>();
@@ -264,47 +258,22 @@ public class MainController {
             }
             logger.info("processing words");
             for (String s : tokens) {
-//                logger.info("processing word: " + s);
                 Index index = new Index(book, s, 1);
-//                RIndex rIndex = new RIndex(s, new ArrayList<>(Set.of(book)));
 
-
-//                logger.info("Pre exists");
                 Boolean exists = allIndexes.contains(index);
-//                Boolean exists = indexRepository.existsByWordAndBook(book, s)!=null ? indexRepository.existsByWordAndBook(book, s) : false;
-//                Boolean rexists = RIndexRepository.existsByWord(s)!=null ? RIndexRepository.existsByWord(s) : false;
-//                logger.info("Post exists");
-
-//                logger.info(exists.toString());
-//                logger.info(rexists.toString());
 
                 if (exists) {
-//                    logger.info("Exist");
-//                    System.err.println(currentIndexes);
                     Index i = allIndexes.get(allIndexes.indexOf(index));
                     i.setFrequency(i.getFrequency() + 1);
-//                    logger.info(Integer.valueOf(i.getFrequency()).toString());
-//                    logger.info(Integer.valueOf(allIndexes.get(allIndexes.indexOf(i)).getFrequency()).toString());
                 } else {
                     allIndexes.add(index);
                 }
-//                if(rexists) {
-//                    logger.info("RExist");
-//                    RIndex r = allRIndexes.get(allRIndexes.indexOf(rIndex));
-//                    if (!r.getBooks().contains(book)) {
-//                        r.addBook(book);
-//                    }
-//                } else {
-//                    allRIndexes.add(rIndex);
-//                }
             }
             logger.info("processed words");
             logger.info("saving indexes");
-//            RIndexRepository.saveAll(allRIndexes.stream().toList());
             indexRepository.saveAll(allIndexes.stream().toList());
             logger.info("saved indexes");
         }
-
 
         return "ok";
     }

--- a/back/src/main/java/com/fadgiras/searchengine/controller/MainController.java
+++ b/back/src/main/java/com/fadgiras/searchengine/controller/MainController.java
@@ -17,7 +17,6 @@ import org.apache.lucene.analysis.en.EnglishAnalyzer;
 import org.apache.lucene.analysis.en.PorterStemFilter;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
-import org.apache.lucene.search.similarities.ClassicSimilarity;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -246,22 +245,21 @@ public class MainController {
             //get index from database
             List<Index> allIndexes = indexRepository.getIndexByBook(book);
 
-            logger.info("processing book: " + book.getTitle());
+            logger.trace("processing book: " + book.getTitle());
             List<String> tokens = new ArrayList<>();
             try {
-                logger.info("stemming book: " + book.getTitle());
+                logger.trace("stemming book: " + book.getTitle());
                 tokens = stem(book.getContent());
-                logger.info("stemmed book: " + book.getTitle());
-                logger.info("tokens: " + tokens.size());
+                logger.trace("stemmed book: " + book.getTitle());
+                logger.trace("tokens: " + tokens.size());
             } catch (Exception e) {
                 e.printStackTrace();
             }
-            logger.info("processing words");
+            logger.trace("processing words");
             for (String s : tokens) {
                 Index index = new Index(book, s, 1);
 
-                Boolean exists = allIndexes.contains(index);
-
+                boolean exists = allIndexes.contains(index);
                 if (exists) {
                     Index i = allIndexes.get(allIndexes.indexOf(index));
                     i.setFrequency(i.getFrequency() + 1);
@@ -269,10 +267,10 @@ public class MainController {
                     allIndexes.add(index);
                 }
             }
-            logger.info("processed words");
-            logger.info("saving indexes");
+            logger.trace("processed words");
+            logger.trace("saving indexes");
             indexRepository.saveAll(allIndexes.stream().toList());
-            logger.info("saved indexes");
+            logger.trace("saved indexes");
         }
 
         return "ok";

--- a/back/src/main/java/com/fadgiras/searchengine/controller/MainController.java
+++ b/back/src/main/java/com/fadgiras/searchengine/controller/MainController.java
@@ -239,7 +239,6 @@ public class MainController {
 
     @RequestMapping(value = "/indexer", produces = "application/json")
     public String indexer() {
-        indexRepository.deleteAll();
         List<Index> allIndexes = bookRepository.findAll()
                 .parallelStream()
                 .map(book -> {

--- a/back/src/main/java/com/fadgiras/searchengine/controller/MainController.java
+++ b/back/src/main/java/com/fadgiras/searchengine/controller/MainController.java
@@ -251,10 +251,10 @@ public class MainController {
                 logger.trace("tokens: {}", tokens.size());
                 logger.trace("processing words");
 
-                Map<String, Long> occurrenceByToken = tokens.stream()
+                Map<String, Long> occurrenceByToken = tokens.parallelStream()
                         .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));
 
-                List<Index> allIndexes = occurrenceByToken.entrySet().stream().map(tokenOccurrence ->
+                List<Index> allIndexes = occurrenceByToken.entrySet().parallelStream().map(tokenOccurrence ->
                         new Index(book, tokenOccurrence.getKey(), (int)(long)tokenOccurrence.getValue())
                 ).collect(Collectors.toList());
 

--- a/back/src/main/java/com/fadgiras/searchengine/controller/MainController.java
+++ b/back/src/main/java/com/fadgiras/searchengine/controller/MainController.java
@@ -250,7 +250,6 @@ public class MainController {
             try {
                 logger.trace("stemming book: {}", book.getTitle());
                 tokens = stem(book.getContent());
-                logger.trace("stemmed book: {}", book.getTitle());
                 logger.trace("tokens: {}", tokens.size());
             } catch (Exception e) {
                 e.printStackTrace();

--- a/back/src/main/java/com/fadgiras/searchengine/controller/MainController.java
+++ b/back/src/main/java/com/fadgiras/searchengine/controller/MainController.java
@@ -239,6 +239,7 @@ public class MainController {
 
     @RequestMapping(value = "/indexer", produces = "application/json")
     public String indexer() {
+        indexRepository.deleteAll();
         bookRepository.findAll()
                 .parallelStream()
                 .forEach(book -> {

--- a/back/src/main/java/com/fadgiras/searchengine/controller/MainController.java
+++ b/back/src/main/java/com/fadgiras/searchengine/controller/MainController.java
@@ -262,7 +262,6 @@ public class MainController {
                 logger.trace("saving indexes");
                 indexRepository.saveAll(allIndexes);
                 logger.trace("saved indexes");
-
             } catch (Exception e) {
                 e.printStackTrace();
             }

--- a/back/src/main/java/com/fadgiras/searchengine/controller/MainController.java
+++ b/back/src/main/java/com/fadgiras/searchengine/controller/MainController.java
@@ -245,13 +245,13 @@ public class MainController {
             //get index from database
             List<Index> allIndexes = indexRepository.getIndexByBook(book);
 
-            logger.trace("processing book: " + book.getTitle());
+            logger.trace("processing book: {}", book.getTitle());
             List<String> tokens = new ArrayList<>();
             try {
-                logger.trace("stemming book: " + book.getTitle());
+                logger.trace("stemming book: {}", book.getTitle());
                 tokens = stem(book.getContent());
-                logger.trace("stemmed book: " + book.getTitle());
-                logger.trace("tokens: " + tokens.size());
+                logger.trace("stemmed book: {}", book.getTitle());
+                logger.trace("tokens: {}", tokens.size());
             } catch (Exception e) {
                 e.printStackTrace();
             }


### PR DESCRIPTION
Yesterday, I was talking with @Fadgiras about the Stream API he just tried.
We talked about this project and I tinkered a bit with it, leading me to this PR.

Instead of fetching data from the database and mutating it, I recompute everything (without deleting already existing data) then write it into database.
I'm also summing every word occurrence per book before creating Index instances.
These two things alone, while testing on @Fadgiras laptop, already did a 2x performance improvement on his machine.

Then I decided to parallelize index instanciation and book processing, while writing data into database each time a book process finishes.
This, in combination with the first optimizing pass, did the trick for a 15x performance improvement on @Fadgiras machine.

Computation for 200 books used to take 30 minutes on @Fadgiras machine before, now it takes 2 minutes.